### PR TITLE
Contexts

### DIFF
--- a/src/store/notifications-context.tsx
+++ b/src/store/notifications-context.tsx
@@ -29,7 +29,7 @@ export const NotificationsProvider: FC<{ children: React.ReactNode }> = ({
   const addNotification = (notificationData: Omit<Notification, 'id' | 'timestamp' | 'read'>) => {
     const newNotification = {
       ...notificationData,
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
       timestamp: new Date(),
       read: false,
     };

--- a/src/store/rides-context.tsx
+++ b/src/store/rides-context.tsx
@@ -50,7 +50,7 @@ export const RidesProvider: FC<{ children: React.ReactNode }> = ({
   const addRequest = (requestData: Omit<RideRequest, 'id'>) => {
     const newRequest = {
       ...requestData,
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
     };
     setRequests(prev => [...prev, newRequest]);
   };

--- a/src/store/rides-context.tsx
+++ b/src/store/rides-context.tsx
@@ -42,7 +42,7 @@ export const RidesProvider: FC<{ children: React.ReactNode }> = ({
   const addOffer = (offerData: Omit<RideOffer, 'id'>) => {
     const newOffer = {
       ...offerData,
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
     };
     setOffers(prev => [...prev, newOffer]);
   };

--- a/src/store/vehicle-context.tsx
+++ b/src/store/vehicle-context.tsx
@@ -29,7 +29,7 @@ export const VehicleProvider: FC<{ children: React.ReactNode }> = ({
   const addVehicle = (vehicleData: Omit<Vehicle, 'id'>) => {
     const newVehicle = {
       ...vehicleData,
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
     };
     setVehicles(prev => [...prev, newVehicle]);
   };

--- a/src/store/voucher-context.tsx
+++ b/src/store/voucher-context.tsx
@@ -32,7 +32,7 @@ export const VoucherProvider: FC<{ children: React.ReactNode }> = ({
   const addTransaction = (transactionData: Omit<VoucherTransaction, 'id' | 'date'>) => {
     const newTransaction = {
       ...transactionData,
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
       date: new Date(),
     };
     setTransactions(prev => [...prev, newTransaction]);


### PR DESCRIPTION
Using Date.now().toString() for ID generation can create duplicate IDs if multiple transactions are added rapidly within the same millisecond. Consider using a more robust ID generation method like crypto.randomUUID() or a UUID library.